### PR TITLE
Fix: Correctly parse player names in manual mode

### DIFF
--- a/server/routes/tournaments.js
+++ b/server/routes/tournaments.js
@@ -123,10 +123,14 @@ router.post('/:tournamentId/category/:categoryId/save-manual-structure', isAuthe
                 if (typeof teamName !== 'string' || teamName.trim() === '') {
                     return res.status(400).json({ error: 'El nombre de uno de los equipos está vacío o no es válido.' });
                 }
+                const playerNames = teamName.split('/').map(name => name.trim());
+                const player1Name = playerNames[0] || 'Jugador 1';
+                const player2Name = playerNames[1] || 'Jugador 2';
+
                 teams.push({
                     _id: new mongoose.Types.ObjectId(),
                     teamName: teamName.trim(),
-                    players: [{ playerName: 'Jugador 1' }, { playerName: 'Jugador 2' }]
+                    players: [{ playerName: player1Name }, { playerName: player2Name }]
                 });
             }
             


### PR DESCRIPTION
In the manual tournament setup, the player names were hardcoded as "Jugador 1" and "Jugador 2".

This change updates the `save-manual-structure` route to parse the team name, which is expected to be in the format "Player A / Player B", to extract the individual player names.

If the team name is not in the expected format, it falls back to the original "Jugador 1" and "Jugador 2" to avoid breaking the application.