### PR TITLE
feat: Implement tournament-specific rankings

### DIFF
--- a/frontend.log
+++ b/frontend.log
@@ -1,0 +1,9 @@
+
+> frontend@0.0.0 dev
+> vite
+
+
+  VITE v5.4.19  ready in 366 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose

--- a/frontend/src/components/RankingManagement.jsx
+++ b/frontend/src/components/RankingManagement.jsx
@@ -1,103 +1,174 @@
 // frontend/src/components/RankingManagement.jsx
 
-import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import React, { useState, useEffect, useCallback } from 'react';
+import axios from '../api/axiosConfig'; // Usamos la instancia de axios configurada
 
 function RankingManagement() {
+    const [tournaments, setTournaments] = useState([]);
+    const [selectedTournament, setSelectedTournament] = useState('');
+    const [selectedCategory, setSelectedCategory] = useState('');
     const [players, setPlayers] = useState([]);
-    const [loading, setLoading] = useState(true);
+    const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
-    const [editingPlayerId, setEditingPlayerId] = useState(null);
-    const [playerData, setPlayerData] = useState({ points: 0 });
 
-    const fetchPlayers = async () => {
+    // Cargar torneos al montar el componente
+    useEffect(() => {
+        const fetchTournaments = async () => {
+            try {
+                const response = await axios.get('/tournaments');
+                setTournaments(response.data);
+            } catch (err) {
+                setError('No se pudieron cargar los torneos.');
+            }
+        };
+        fetchTournaments();
+    }, []);
+
+    // Cargar jugadores cuando se selecciona un torneo y categoría
+    const fetchPlayersForCategory = useCallback(async () => {
+        if (!selectedTournament || !selectedCategory) {
+            setPlayers([]);
+            return;
+        }
+
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await axios.get(`/ranking/players/${selectedTournament}/${encodeURIComponent(selectedCategory)}`);
+            // Inicializamos los puntos si no vienen en la respuesta
+            const playersWithPoints = response.data.map(p => ({ ...p, points: p.points || 0 }));
+            setPlayers(playersWithPoints);
+        } catch (err) {
+            setError('No se pudieron cargar los jugadores para esta categoría.');
+            setPlayers([]);
+        } finally {
+            setLoading(false);
+        }
+    }, [selectedTournament, selectedCategory]);
+
+    useEffect(() => {
+        fetchPlayersForCategory();
+    }, [fetchPlayersForCategory]);
+
+    const handlePointsChange = (playerId, newPoints) => {
+        setPlayers(prevPlayers =>
+            prevPlayers.map(p =>
+                p._id === playerId ? { ...p, points: newPoints } : p
+            )
+        );
+    };
+
+    const handleSavePoints = async () => {
+        if (!selectedTournament || !selectedCategory) return;
+
+        const playersPoints = players.map(p => ({
+            playerId: p._id,
+            points: p.points
+        }));
+
         try {
             setLoading(true);
-            const response = await axios.get('/players');
-            // Ordenamos por apellido para que sea más fácil de encontrar
-            setPlayers(response.data.sort((a, b) => a.lastName.localeCompare(b.lastName)));
-            setError(null);
+            await axios.post('/ranking/update', {
+                tournamentId: selectedTournament,
+                categoryName: selectedCategory,
+                playersPoints: playersPoints
+            });
+            alert('Puntos actualizados correctamente.');
+            fetchPlayersForCategory(); // Recargar para confirmar
         } catch (err) {
-            setError('No se pudo cargar la lista de jugadores.');
+            setError('Error al guardar los puntos.');
         } finally {
             setLoading(false);
         }
     };
 
-    useEffect(() => {
-        fetchPlayers();
-    }, []);
-
-    const handleEditClick = (player) => {
-        setEditingPlayerId(player._id);
-        setPlayerData({ points: player.points });
-    };
-
-    const handleCancel = () => {
-        setEditingPlayerId(null);
-    };
-
-    const handleSave = async (playerId) => {
-        try {
-            await axios.put(`/players/${playerId}`, { points: playerData.points });
-            setEditingPlayerId(null);
-            fetchPlayers(); // Recargamos para ver los puntos actualizados y reordenar
-        } catch (err) {
-            alert('Error al actualizar los puntos del jugador.');
-        }
-    };
+    const categoriesForSelectedTournament = selectedTournament
+        ? tournaments.find(t => t._id === selectedTournament)?.categories.map(c => c.name) ?? []
+        : [];
 
     return (
-        <div className="animate-fade-in">
-            <h3 className="text-2xl font-semibold text-white mb-6">Gestión de Puntos del Ranking</h3>
-            <p className="text-gray-400 mb-6">
-                Aquí puedes ver todos los jugadores registrados en el sistema. Haz clic en "Editar" para modificar los puntos de un jugador en el ranking.
-            </p>
+        <div className="animate-fade-in p-4 sm:p-6 bg-gray-900 rounded-lg shadow-xl">
+            <h3 className="text-2xl font-bold text-white mb-6">Gestión de Puntos por Torneo</h3>
 
-            {loading && <div className="loading-spinner mx-auto"></div>}
-            {error && <p className="text-red-400 text-center">{error}</p>}
-            {!loading && !error && (
-                <div className="bg-gray-800 rounded-lg shadow-lg overflow-hidden">
-                    <table className="min-w-full text-left">
-                        <thead className="bg-gray-700">
-                            <tr>
-                                <th className="p-4">Jugador</th>
-                                <th className="p-4">Categoría</th>
-                                <th className="p-4">Puntos Actuales</th>
-                                <th className="p-4 text-center">Acciones</th>
-                            </tr>
-                        </thead>
-                        <tbody className="divide-y divide-gray-700">
-                            {players.map(player => (
-                                <tr key={player._id}>
-                                    <td className="p-4 font-medium text-white">{`${player.lastName}, ${player.firstName}`}</td>
-                                    <td className="p-4 text-gray-400">{player.category}</td>
-                                    <td className="p-4">
-                                        {editingPlayerId === player._id ? (
-                                            <input 
-                                                type="number" 
-                                                value={playerData.points}
-                                                onChange={(e) => setPlayerData({ ...playerData, points: e.target.value })}
-                                                className="bg-gray-900 p-2 w-24 rounded text-white"
-                                            />
-                                        ) : (
-                                            <span className="font-bold text-green-400">{player.points}</span>
-                                        )}
-                                    </td>
-                                    <td className="p-4 text-center">
-                                        {editingPlayerId === player._id ? (
-                                            <div className="flex gap-2 justify-center">
-                                                <button onClick={() => handleSave(player._id)} className="bg-green-600 px-3 py-1 rounded text-sm font-semibold">Guardar</button>
-                                                <button onClick={handleCancel} className="bg-gray-600 px-3 py-1 rounded text-sm">Cancelar</button>
-                                            </div>
-                                        ) : (
-                                            <button onClick={() => handleEditClick(player)} className="bg-blue-600 px-3 py-1 rounded text-sm font-semibold">Editar Puntos</button>
-                                        )}
-                                    </td>
+            {/* Selectores de Torneo y Categoría */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+                <div>
+                    <label htmlFor="tournament-select" className="block text-sm font-medium text-gray-300 mb-2">Seleccionar Torneo</label>
+                    <select
+                        id="tournament-select"
+                        value={selectedTournament}
+                        onChange={(e) => {
+                            setSelectedTournament(e.target.value);
+                            setSelectedCategory(''); // Reset category on tournament change
+                            setPlayers([]);
+                        }}
+                        className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg p-2 focus:ring-2 focus:ring-green-500"
+                    >
+                        <option value="">-- Elige un torneo --</option>
+                        {tournaments.map(t => <option key={t._id} value={t._id}>{t.name}</option>)}
+                    </select>
+                </div>
+                <div>
+                    <label htmlFor="category-select" className="block text-sm font-medium text-gray-300 mb-2">Seleccionar Categoría</label>
+                    <select
+                        id="category-select"
+                        value={selectedCategory}
+                        onChange={(e) => setSelectedCategory(e.target.value)}
+                        disabled={!selectedTournament}
+                        className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg p-2 focus:ring-2 focus:ring-green-500 disabled:opacity-50"
+                    >
+                        <option value="">-- Elige una categoría --</option>
+                        {categoriesForSelectedTournament.map(c => <option key={c} value={c}>{c}</option>)}
+                    </select>
+                </div>
+            </div>
+
+            {/* Lista de Jugadores y Puntos */}
+            {loading && <div className="loading-spinner mx-auto my-8"></div>}
+            {error && <p className="text-red-400 text-center my-4">{error}</p>}
+
+            {selectedTournament && selectedCategory && !loading && !error && (
+                <div>
+                    <div className="bg-gray-800 rounded-lg shadow-md overflow-hidden">
+                        <table className="min-w-full text-left">
+                            <thead className="bg-gray-700">
+                                <tr>
+                                    <th className="p-4">Jugador</th>
+                                    <th className="p-4 w-32 text-center">Puntos</th>
                                 </tr>
-                            ))}
-                        </tbody>
-                    </table>
+                            </thead>
+                            <tbody className="divide-y divide-gray-700">
+                                {players.length > 0 ? (
+                                    players.map(player => (
+                                        <tr key={player._id}>
+                                            <td className="p-4 font-medium text-white">{`${player.lastName}, ${player.firstName}`}</td>
+                                            <td className="p-4">
+                                                <input
+                                                    type="number"
+                                                    value={player.points}
+                                                    onChange={(e) => handlePointsChange(player._id, parseInt(e.target.value, 10) || 0)}
+                                                    className="w-full bg-gray-900 p-2 rounded text-white text-center"
+                                                />
+                                            </td>
+                                        </tr>
+                                    ))
+                                ) : (
+                                    <tr>
+                                        <td colSpan="2" className="p-4 text-center text-gray-400">No hay jugadores en esta categoría.</td>
+                                    </tr>
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                    <div className="mt-6 text-right">
+                        <button
+                            onClick={handleSavePoints}
+                            disabled={players.length === 0}
+                            className="bg-green-600 hover:bg-green-700 px-6 py-2 rounded text-white font-semibold shadow-lg transition disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            Guardar Puntos
+                        </button>
+                    </div>
                 </div>
             )}
         </div>

--- a/frontend/src/pages/Standings.jsx
+++ b/frontend/src/pages/Standings.jsx
@@ -1,90 +1,139 @@
 // frontend/src/pages/Standings.jsx
 
 import React, { useState, useEffect, useMemo } from 'react';
-import axios from 'axios';
+import axios from '../api/axiosConfig';
+
+const getMedalColor = (index) => {
+    switch (index) {
+        case 0:
+            return 'bg-yellow-500/20 text-yellow-300 border-yellow-500'; // Oro
+        case 1:
+            return 'bg-gray-400/20 text-gray-200 border-gray-400'; // Plata
+        case 2:
+            return 'bg-yellow-800/20 text-yellow-600 border-yellow-700'; // Bronce
+        default:
+            return 'border-transparent';
+    }
+};
 
 function Standings() {
-    const [players, setPlayers] = useState([]);
-    const [loading, setLoading] = useState(true);
+    const [tournaments, setTournaments] = useState([]);
+    const [selectedTournamentId, setSelectedTournamentId] = useState('');
+    const [rankings, setRankings] = useState({});
+    const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
-    const [selectedCategory, setSelectedCategory] = useState('Todas');
 
+    // Cargar todos los torneos al inicio
     useEffect(() => {
-        const fetchPlayers = async () => {
+        const fetchTournaments = async () => {
             try {
-                // Ahora obtenemos los jugadores, que ya vienen ordenados por puntos
-                const response = await axios.get('/players');
-                setPlayers(response.data);
+                setLoading(true);
+                const response = await axios.get('/tournaments');
+                setTournaments(response.data);
+                // Opcional: seleccionar el primer torneo por defecto
+                if (response.data.length > 0) {
+                    setSelectedTournamentId(response.data[0]._id);
+                }
             } catch (err) {
-                setError("No se pudo cargar el ranking.");
+                setError('No se pudieron cargar los torneos.');
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchTournaments();
+    }, []);
+
+    // Cargar rankings cuando se selecciona un torneo
+    useEffect(() => {
+        if (!selectedTournamentId) return;
+
+        const fetchRankingsForTournament = async () => {
+            const tournament = tournaments.find(t => t._id === selectedTournamentId);
+            if (!tournament) return;
+
+            setLoading(true);
+            setError(null);
+            const newRankings = {};
+
+            try {
+                for (const category of tournament.categories) {
+                    const response = await axios.get(`/ranking/${selectedTournamentId}/${encodeURIComponent(category.name)}`);
+                    newRankings[category.name] = response.data;
+                }
+                setRankings(newRankings);
+            } catch (err) {
+                setError('No se pudo cargar el ranking para este torneo.');
             } finally {
                 setLoading(false);
             }
         };
 
-        fetchPlayers();
-    }, []);
+        fetchRankingsForTournament();
+    }, [selectedTournamentId, tournaments]);
 
-    const categories = useMemo(() => {
-        if (players.length === 0) return [];
-        return ['Todas', ...Array.from(new Set(players.map(player => player.category)))];
-    }, [players]);
-
-    const filteredRanking = useMemo(() => {
-        if (selectedCategory === 'Todas') {
-            return players;
-        }
-        return players.filter(player => player.category === selectedCategory);
-    }, [players, selectedCategory]);
-
-    if (loading) return <div className="loading-spinner mx-auto mt-10"></div>;
-    if (error) return <p className="text-red-400 text-center mt-10">{error}</p>;
+    const selectedTournament = useMemo(() => {
+        return tournaments.find(t => t._id === selectedTournamentId);
+    }, [selectedTournamentId, tournaments]);
 
     return (
-        <div className="max-w-4xl mx-auto">
-            <h2 className="text-3xl font-extrabold text-white text-center mb-8">Ranking Oficial de Jugadores</h2>
+        <div className="max-w-7xl mx-auto p-4 animate-fade-in">
+            <h2 className="text-3xl font-extrabold text-white text-center mb-8">Ranking por Torneo</h2>
 
-            <div className="flex flex-wrap justify-center gap-2 mb-8">
-                {categories.map(category => (
-                    <button
-                        key={category}
-                        onClick={() => setSelectedCategory(category)}
-                        className={`px-4 py-2 text-sm font-semibold rounded-full transition ${
-                            selectedCategory === category
-                                ? 'bg-green-600 text-white shadow-lg'
-                                : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
-                        }`}
-                    >
-                        {category}
-                    </button>
-                ))}
+            {/* Selector de Torneo */}
+            <div className="max-w-md mx-auto mb-8">
+                <label htmlFor="tournament-select" className="block text-sm font-medium text-gray-300 mb-2">
+                    Selecciona un Torneo
+                </label>
+                <select
+                    id="tournament-select"
+                    value={selectedTournamentId}
+                    onChange={(e) => setSelectedTournamentId(e.target.value)}
+                    className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg p-3 focus:ring-2 focus:ring-green-500"
+                >
+                    <option value="">-- Elige un torneo --</option>
+                    {tournaments.map(t => <option key={t._id} value={t._id}>{t.name}</option>)}
+                </select>
             </div>
 
-            <div className="bg-gray-800 rounded-lg shadow-lg overflow-hidden">
-                <table className="min-w-full text-left">
-                    <thead className="bg-gray-700">
-                        <tr>
-                            <th className="p-4 font-semibold text-sm text-gray-300 uppercase tracking-wider">Pos.</th>
-                            <th className="p-4 font-semibold text-sm text-gray-300 uppercase tracking-wider">Jugador</th>
-                            <th className="p-4 font-semibold text-sm text-gray-300 uppercase tracking-wider">Categoría</th>
-                            <th className="p-4 font-semibold text-sm text-gray-300 uppercase tracking-wider text-right">Puntos</th>
-                        </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-700">
-                        {filteredRanking.map((player, index) => (
-                            <tr key={player._id} className="hover:bg-gray-700/50">
-                                <td className="p-4 font-bold text-lg">{index + 1}</td>
-                                <td className="p-4">
-                                    <p className="font-medium text-white">{`${player.firstName} ${player.lastName}`}</p>
-                                    <p className="text-sm text-gray-400">DNI: {player.dni}</p>
-                                </td>
-                                <td className="p-4 text-gray-400">{player.category}</td>
-                                <td className="p-4 font-bold text-green-400 text-right">{player.points}</td>
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
+            {loading && <div className="loading-spinner mx-auto my-10"></div>}
+            {error && <p className="text-red-400 text-center my-10">{error}</p>}
+
+            {!loading && !error && selectedTournament && (
+                <div className="space-y-12">
+                    {selectedTournament.categories.map(category => (
+                        <div key={category.name}>
+                            <h3 className="text-2xl font-bold text-green-400 mb-4">{category.name}</h3>
+                            <div className="bg-gray-800/50 backdrop-blur-sm rounded-lg shadow-lg overflow-hidden">
+                                {rankings[category.name] && rankings[category.name].length > 0 ? (
+                                    <table className="min-w-full text-left">
+                                        <thead className="bg-gray-700/50">
+                                            <tr>
+                                                <th className="p-4 w-16 font-semibold text-sm text-gray-300 uppercase tracking-wider text-center">Pos.</th>
+                                                <th className="p-4 font-semibold text-sm text-gray-300 uppercase tracking-wider">Jugador</th>
+                                                <th className="p-4 w-24 font-semibold text-sm text-gray-300 uppercase tracking-wider text-right">Puntos</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody className="divide-y divide-gray-700">
+                                            {rankings[category.name].map((entry, index) => (
+                                                <tr key={entry._id} className={`transition hover:bg-gray-700/50 border-l-4 ${getMedalColor(index)}`}>
+                                                    <td className="p-4 font-bold text-lg text-center">{index + 1}</td>
+                                                    <td className="p-4">
+                                                        <p className="font-medium text-white">{`${entry.player.lastName}, ${entry.player.firstName}`}</p>
+                                                        <p className="text-sm text-gray-400">DNI: {entry.player.dni}</p>
+                                                    </td>
+                                                    <td className="p-4 font-bold text-green-400 text-right text-lg">{entry.points}</td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                ) : (
+                                    <p className="p-6 text-center text-gray-400">No hay datos de ranking para esta categoría todavía.</p>
+                                )}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
         </div>
     );
 }

--- a/server.log
+++ b/server.log
@@ -1,0 +1,9 @@
+
+> padel-chilecito-backend@1.0.0 dev
+> nodemon index.js
+
+[33m[nodemon] 3.1.10[39m
+[33m[nodemon] to restart at any time, enter `rs`[39m
+[33m[nodemon] watching path(s): *.*[39m
+[33m[nodemon] watching extensions: js,mjs,cjs,json[39m
+[32m[nodemon] starting `node index.js`[39m

--- a/server/index.js
+++ b/server/index.js
@@ -50,8 +50,7 @@ app.use('/api/tournaments', require('./routes/tournaments'));
 app.use('/api/news', require('./routes/news'));
 app.use('/api/ads', require('./routes/ads'));
 app.use('/api/gallery', require('./routes/gallery'));
-// --- ¡LÍNEA ELIMINADA! Ya no usamos la ruta del ranking antiguo ---
-// app.use('/api/ranking', require('./routes/ranking')); 
+app.use('/api/ranking', require('./routes/ranking'));
 app.use('/api/seed', require('./routes/seed'));
 app.use('/api/community', require('./routes/community'));
 app.use('/api/livestream', require('./routes/livestream'));

--- a/server/models/Player.js
+++ b/server/models/Player.js
@@ -24,10 +24,6 @@ const playerSchema = new mongoose.Schema({
         type: String,
         required: true,
     },
-    points: { // Nuevo campo para el ranking
-        type: Number,
-        default: 0,
-    },
     registrationDate: {
         type: Date,
         default: Date.now,

--- a/server/models/Ranking.js
+++ b/server/models/Ranking.js
@@ -1,30 +1,33 @@
-// server/models/Ranking.js
-
 const mongoose = require('mongoose');
 
 const rankingSchema = new mongoose.Schema({
-    teamName: {
-        type: String,
-        required: true,
-        unique: true // No puede haber dos equipos con el mismo nombre en el ranking
-    },
-    player1Name: {
-        type: String,
+    tournament: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Tournament',
         required: true,
     },
-    player2Name: {
+    categoryName: {
         type: String,
         required: true,
     },
-    category: {
-        type: String,
+    player: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Player',
         required: true,
     },
     points: {
         type: Number,
         default: 0,
     },
+}, {
+    // Evita la creación de un índice único compuesto incorrecto si se recrea
+    autoIndex: false,
+    timestamps: true
 });
+
+// Índice único para asegurar que un jugador no tenga múltiples entradas de ranking
+// en la misma categoría del mismo torneo.
+rankingSchema.index({ tournament: 1, categoryName: 1, player: 1 }, { unique: true });
 
 const Ranking = mongoose.model('Ranking', rankingSchema);
 


### PR DESCRIPTION
This commit introduces a new ranking system that is specific to tournaments and categories.

The key changes are:
- The data model has been updated to store rankings per tournament and category.
- New API endpoints have been created to manage these rankings.
- The admin UI has been updated to allow managing points for players in a specific tournament and category.
- The public standings page has been updated to display the new rankings with a tournament selector and category tabs.
- The top three players in each ranking are highlighted with gold, silver, and bronze styling.