### PR TITLE
fix(ranking): Resolve E11000 duplicate key error on teamName

### DIFF
--- a/server/models/Ranking.js
+++ b/server/models/Ranking.js
@@ -19,6 +19,10 @@ const rankingSchema = new mongoose.Schema({
         type: Number,
         default: 0,
     },
+    teamName: {
+        type: String,
+        default: null,
+    }
 }, {
     // Evita la creación de un índice único compuesto incorrecto si se recrea
     autoIndex: false,
@@ -28,6 +32,9 @@ const rankingSchema = new mongoose.Schema({
 // Índice único para asegurar que un jugador no tenga múltiples entradas de ranking
 // en la misma categoría del mismo torneo.
 rankingSchema.index({ tournament: 1, categoryName: 1, player: 1 }, { unique: true });
+
+// Índice único disperso para el nombre del equipo, para evitar errores con valores nulos
+rankingSchema.index({ teamName: 1 }, { unique: true, sparse: true });
 
 const Ranking = mongoose.model('Ranking', rankingSchema);
 


### PR DESCRIPTION
This commit fixes a 500 Internal Server Error that occurred when updating ranking points. The error was caused by a unique index on the `teamName` field in the `rankings` collection, which conflicted when multiple entries had a `null` value for `teamName`.

The fix involves updating the `Ranking` model schema in `server/models/Ranking.js` to:
1.  Explicitly include the `teamName` field.
2.  Use a sparse unique index (`unique: true, sparse: true`) for `teamName`. This ensures uniqueness is only enforced for documents that have a non-null value for the field.