### PR TITLE
chore: Add debug logs to player registration route

### DIFF
--- a/server/routes/players.js
+++ b/server/routes/players.js
@@ -22,8 +22,15 @@ router.post('/register', isAuthenticated, async (req, res) => {
     try {
         const { firstName, lastName, dni, phone, category, points } = req.body;
 
+        // --- DEBUGGING LOG ---
+        console.log(`[DEBUG] Registering player. DNI received: '${dni}' (Type: ${typeof dni})`);
+        // ---
+
         // Solo verificar el DNI si se proporciona uno
         if (dni) {
+            // --- DEBUGGING LOG ---
+            console.log(`[DEBUG] DNI is present, checking for existing player...`);
+            // ---
             const existingPlayer = await Player.findOne({ dni });
             if (existingPlayer) {
                 return res.status(400).json({ error: 'Ya existe un jugador con este DNI.' });


### PR DESCRIPTION
This commit adds temporary console.log statements to the POST /api/players/register route. This is for the purpose of debugging an issue where creating a player without a DNI incorrectly fails with a "DNI already exists" error.

The logs will show the exact value and type of the `dni` field as it is received by the server, which will help diagnose if the issue is in the code logic or the data being sent.