### PR TITLE
fix: Rely on sparse index for DNI validation

### DIFF
--- a/server/routes/players.js
+++ b/server/routes/players.js
@@ -22,27 +22,15 @@ router.post('/register', isAuthenticated, async (req, res) => {
     try {
         const { firstName, lastName, dni, phone, category, points } = req.body;
 
-        // --- DEBUGGING LOG ---
-        console.log(`[DEBUG] Registering player. DNI received: '${dni}' (Type: ${typeof dni})`);
-        // ---
-
-        // Solo verificar el DNI si se proporciona uno
-        if (dni) {
-            // --- DEBUGGING LOG ---
-            console.log(`[DEBUG] DNI is present, checking for existing player...`);
-            // ---
-            const existingPlayer = await Player.findOne({ dni });
-            if (existingPlayer) {
-                return res.status(400).json({ error: 'Error de DNI v2: Ya existe un jugador con este DNI.' });
-            }
-        }
-
+        // La validación de DNI único ahora es manejada por el índice 'sparse' en la base de datos.
+        // Esto evita la comprobación manual y soluciona el error con valores nulos.
         const newPlayer = new Player({ firstName, lastName, dni, phone, category, points });
         await newPlayer.save();
         res.status(201).json({ message: 'Jugador registrado exitosamente', player: newPlayer });
     } catch (error) {
+        // El código 11000 es para error de clave duplicada (DNI en este caso)
         if (error.code === 11000) {
-             return res.status(400).json({ error: 'Error de DNI v2: Ya existe un jugador con este DNI.' });
+             return res.status(400).json({ error: 'Ya existe un jugador con el DNI proporcionado.' });
         }
         res.status(500).json({ error: 'Error al registrar el jugador.' });
     }


### PR DESCRIPTION
This commit provides a definitive fix for the "DNI already exists" error that occurred when creating multiple players without a DNI.

The previous manual check (`if (dni)`) in the player registration route was flawed and was incorrectly being triggered. This manual check has been removed entirely.

The application now relies solely on the `unique: true, sparse: true` index on the `dni` field in the `Player` model. This is the robust, correct way to enforce uniqueness on an optional field, as the database itself will only validate non-null values. The route's `catch` block will handle any legitimate duplicate key errors from the database.