### PR TITLE
The application was showing a black screen on Apple mobile devices du…

### DIFF
--- a/frontend/src/components/NotificationManager.jsx
+++ b/frontend/src/components/NotificationManager.jsx
@@ -4,13 +4,15 @@ import React, { useState, useEffect } from 'react';
 import { subscribeUserToPush } from '../utils/notifications';
 
 function NotificationManager() {
-    const [permission, setPermission] = useState(Notification.permission);
+    const [permission, setPermission] = useState(''); // Inicialización segura para evitar errores en navegadores estrictos
     const [isSupported, setIsSupported] = useState(false);
     const [isDismissed, setIsDismissed] = useState(false);
 
     useEffect(() => {
+        // Comprobar la compatibilidad y obtener el estado del permiso de forma segura
         if ('Notification' in window && 'serviceWorker' in navigator && 'PushManager' in window) {
             setIsSupported(true);
+            setPermission(Notification.permission); // Obtener el permiso solo después de confirmar la compatibilidad
         }
     }, []);
 


### PR DESCRIPTION
…e to a JavaScript error during the initial rendering.

The `NotificationManager` component was attempting to access `Notification.permission` directly in the `useState` hook. On iOS, especially when running as a PWA, the `Notification` object may not be available at the moment of script evaluation, causing a `TypeError` that halts execution and prevents the app from rendering.

This commit fixes the issue by:
1.  Initializing the `permission` state to a safe, empty string.
2.  Moving the logic to access `Notification.permission` inside a `useEffect` hook. This ensures the code only runs after the component has mounted and after verifying that the Notification API is supported by the browser.

This change resolves the critical rendering failure, allowing the application to load correctly on iOS devices.