### PR TITLE
feat: Implement tournament enhancements and operator role

### DIFF
--- a/frontend/src/pages/OperatorPage.jsx
+++ b/frontend/src/pages/OperatorPage.jsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useEffect } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { AuthContext } from '../context/AuthContext';
+import { useAuth } from '../context/AuthContext';
 
 function OperatorPage() {
     const [searchParams] = useSearchParams();
     const navigate = useNavigate();
-    const { setAuthToken } = useContext(AuthContext);
+    const { setAuthToken } = useAuth();
 
     useEffect(() => {
         const token = searchParams.get('token');

--- a/frontend/src/pages/OperatorTournamentView.jsx
+++ b/frontend/src/pages/OperatorTournamentView.jsx
@@ -1,13 +1,13 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams, Navigate, useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import { AuthContext } from '../context/AuthContext';
+import { useAuth } from '../context/AuthContext';
 import TournamentDetails from '../components/TournamentDetails'; // Reutilizaremos esto
 
 function OperatorTournamentView() {
     const { tournamentId } = useParams();
     const navigate = useNavigate();
-    const { token, isOperator, operatorTournamentId } = useContext(AuthContext);
+    const { token, isOperator, operatorTournamentId } = useAuth();
     const [tournament, setTournament] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');


### PR DESCRIPTION
This commit introduces several major enhancements to the tournament management system, focusing on regulatory alignment, increased flexibility, and a new user role for simplified operations.

Key features implemented:

1.  **APA Official Match System:**
    - Added a `zonePlaySystem` option for tournament categories.
    - When enabled for a 4-team zone, the system now generates matches according to the official APA regulations (1 vs. 3, 2 vs. 4, followed by winners vs. winners and losers vs. losers).
    - Includes placeholder matches that are populated via a new API endpoint after the initial round is complete.

2.  **Advanced Tournament Configuration:**
    - The tournament creation form now includes options to "Enable Seeding" (`useSeedings`) and "Avoid Same-Club Conflicts" (`avoidClubConflicts`).
    - The backend logic for team distribution (`_distributeInZones`) has been enhanced to respect these settings.

3.  **New 'Operator' Role:**
    - Created a new, limited-permission 'Operator' role to allow designated users to manage match results for a single tournament.
    - Admins can now generate a short-lived (48h), tournament-specific access link.
    - An end-to-end flow handles token generation, validation, and a restricted UI for operators.